### PR TITLE
Remove stray debug lines

### DIFF
--- a/gaze_correction_system/regz_socket_MP_FD.py
+++ b/gaze_correction_system/regz_socket_MP_FD.py
@@ -96,8 +96,6 @@ def get_window_rect(title):
 # In[ ]:
 
 
-model_dir
-print(Rs)
 
 
 # In[ ]:


### PR DESCRIPTION
## Summary
- remove leftover `model_dir` expression
- drop `print(Rs)` debug output

## Testing
- `python -m py_compile gaze_correction_system/regz_socket_MP_FD.py`

------
https://chatgpt.com/codex/tasks/task_e_6848ac4e0c988331a6a49e5428366f46